### PR TITLE
feat: config path also follows XDG_CONFIG_DIR

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -21,9 +21,15 @@ std::filesystem::path Config::getConfigDirectory()
         free(appData);
     }
 #else
-    // Linux/macOS: ~/.config/presence-for-plex
+    // Unix/Linux/macOS: $XDG_CONFIG_DIR/presence-for-plex or ~/.config/presence-for-plex
+    char *xdgConfig = getenv("XDG_CONFIG_DIR");
     char *home = getenv("HOME");
-    if (home)
+
+    if (xdgConfig)
+    {
+        configDir = std::filesystem::path(xdgConfig) / "presence-for-plex";
+    }
+    else if (home)
     {
         configDir = std::filesystem::path(home) / ".config" / "presence-for-plex";
     }

--- a/src/discord_ipc.cpp
+++ b/src/discord_ipc.cpp
@@ -144,12 +144,12 @@ bool DiscordIPC::openPipe()
     {
         std::string socket_path;
         // Check environment variables first (XDG standard)
-        const char *temp = getenv("XDG_RUNTIME_DIR");
+        const char *xdgRuntime = getenv("XDG_RUNTIME_DIR");
         const char *home = getenv("HOME");
 
-        if (temp)
+        if (xdgRuntime)
         {
-            socket_path = std::string(temp) + "/discord-ipc-" + std::to_string(i);
+            socket_path = std::string(xdgRuntime) + "/discord-ipc-" + std::to_string(i);
         }
         else if (home)
         {


### PR DESCRIPTION
Hi, I think it would be cool if the app also resolves `$XDG_CONFIG_DIR` - if it exists - but it can still fallback to the current one.

This would allow a little bit of flexibility.