### PR TITLE
feat: add Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,30 +28,38 @@ if(WIN32)
   set(RES_FILES assets/resources.rc)
 endif()
 
-# Packages
-include(FetchContent)
-
-## yaml-cpp
-FetchContent_Declare(
-	yaml-cpp
-	GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-	GIT_TAG master
-) 
-FetchContent_MakeAvailable(yaml-cpp)
-
-## nlohmann_json
-FetchContent_Declare(
-  json
-  URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
-)
-FetchContent_MakeAvailable(json)
-
-## curl
-FetchContent_Declare(
-  curl
-  URL https://github.com/curl/curl/releases/download/curl-7_86_0/curl-7.86.0.tar.gz
-)
-FetchContent_MakeAvailable(curl)
+# Allow to use system libraries
+if(USE_DYNAMIC_LINKS)
+    find_package(CURL REQUIRED)
+    find_package(nlohmann_json REQUIRED)
+    find_package(yaml-cpp REQUIRED)
+else()
+    # Packages
+    include(FetchContent)
+    set(BUILD_SHARED_LIBS OFF)
+    
+    ## yaml-cpp
+    FetchContent_Declare(
+      yaml-cpp
+      GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+      GIT_TAG master
+    )
+    FetchContent_MakeAvailable(yaml-cpp)
+    
+    ## nlohmann_json
+    FetchContent_Declare(
+      json
+      URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+    )
+    FetchContent_MakeAvailable(json)
+    
+    ## curl
+    FetchContent_Declare(
+      curl
+      URL https://github.com/curl/curl/releases/download/curl-7_86_0/curl-7.86.0.tar.gz
+    )
+    FetchContent_MakeAvailable(curl)
+endif()
 
 # Add source to this project's executable.
 if(WIN32)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM public.ecr.aws/docker/library/alpine:3.22 AS base
+
+FROM base AS build
+RUN apk add --no-cache build-base cmake samurai \
+                       linux-headers pkgconf git curl perl zip bash
+
+ARG VCPKG_VERSION=2025.04.09
+ENV VCPKG_ROOT=/vcpkg VCPKG_FORCE_SYSTEM_BINARIES=1 \
+    VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads \
+ADD https://github.com/microsoft/vcpkg.git#$VCPKG_VERSION $VCPKG_ROOT
+RUN mkdir -p $VCPKG_DOWNLOADS && \
+    $VCPKG_ROOT/bootstrap-vcpkg.sh -disableMetrics
+
+COPY . /src
+WORKDIR /src
+ARG BUILD_TYPE=debug
+RUN --mount=type=cache,target=/root/.cache/vcpkg \
+    cmake -B ./build -G Ninja \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+          -DCMAKE_EXE_LINKER_FLAGS=-static && \
+    cmake --build ./build
+
+FROM base AS runtime
+COPY --from=build --chmod=755 /src/build/PresenceForPlex /app/
+
+ENV HOME=/app XDG_RUNTIME_DIR=/app
+VOLUME /app/.config
+CMD ["/app/PresenceForPlex"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
 FROM public.ecr.aws/docker/library/alpine:3.22 AS base
 
 FROM base AS build
-RUN apk add --no-cache build-base cmake samurai \
-                       curl-dev yaml-cpp-dev nlohmann-json
+RUN apk add --no-cache build-base cmake samurai git openssl-dev
 
 COPY . /src
 WORKDIR /src
 ARG BUILD_TYPE=debug
-RUN cmake -B ./build -G Ninja \
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DUSE_DYNAMIC_LINKS=ON && \
-    cmake --build ./build && \
-    strip ./build/PresenceForPlex
+RUN cmake -B ./build -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE && \
+    cmake --build ./build
 
 FROM base AS runtime
-RUN apk add --no-cache curl yaml-cpp
+RUN apk add --no-cache libstdc++
 COPY --from=build --chmod=755 /src/build/PresenceForPlex /app/
 
 ENV HOME=/app XDG_CONFIG_DIR=/config XDG_RUNTIME_DIR=/app/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,21 @@ FROM public.ecr.aws/docker/library/alpine:3.22 AS base
 
 FROM base AS build
 RUN apk add --no-cache build-base cmake samurai \
-                       linux-headers pkgconf git curl perl zip bash
-
-ARG VCPKG_VERSION=2025.04.09
-ENV VCPKG_ROOT=/vcpkg VCPKG_FORCE_SYSTEM_BINARIES=1 \
-    VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads \
-ADD https://github.com/microsoft/vcpkg.git#$VCPKG_VERSION $VCPKG_ROOT
-RUN mkdir -p $VCPKG_DOWNLOADS && \
-    $VCPKG_ROOT/bootstrap-vcpkg.sh -disableMetrics
+                       curl-dev yaml-cpp-dev nlohmann-json
 
 COPY . /src
 WORKDIR /src
 ARG BUILD_TYPE=debug
-RUN --mount=type=cache,target=/root/.cache/vcpkg \
-    cmake -B ./build -G Ninja \
+RUN cmake -B ./build -G Ninja \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
-          -DCMAKE_EXE_LINKER_FLAGS=-static && \
-    cmake --build ./build
+          -DUSE_DYNAMIC_LINKS=ON && \
+    cmake --build ./build && \
+    strip ./build/PresenceForPlex
 
 FROM base AS runtime
+RUN apk add --no-cache curl yaml-cpp
 COPY --from=build --chmod=755 /src/build/PresenceForPlex /app/
 
-ENV HOME=/app XDG_RUNTIME_DIR=/app
-VOLUME /app/.config
+ENV HOME=/app XDG_CONFIG_DIR=/config XDG_RUNTIME_DIR=/app/run
+VOLUME /config/presence-for-plex
 CMD ["/app/PresenceForPlex"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ If the application is connecting to your Plex server but not detecting your medi
 
 They do, but only for others! For some reason Discord doesn't like to show you your own rich presence buttons.
 
+### Could not connect to any Discord socket. Is Discord running?
+
+You need to have a Discord app running in the same machine as the application.
+
+It will try to connect to Discord using the following files:
+
+-   Windows: `\\.pipe\discord-ipc-0` to `discord-ipc-9`
+-   macOS: `$TMPDIR/discord-ipc-0` to `discord-ipc-9`
+-   Linux:
+    - `$XDG_RUNTIME_DIR/discord-ipc-0` to `discord-ipc-9`
+    - `$HOME/.discord-ipc-0` to `discord-ipc-9`
+    - `/var/run/$UID/snap.discord/discord-ipc-0`
+    - `/var/run/$UID/app/com.discordapp.Discord/discord-ipc-0`
+
+If none of those succeed, it means it can not talk to your Discord local client.
+
 ## Attribution
 
 ![blue_square_2-d537fb228cf3ded904ef09b136fe3fec72548ebc1fea3fbbd1ad9e36364db38b](https://github.com/user-attachments/assets/38abfb34-72cf-46d9-9d17-724761aa570a)


### PR DESCRIPTION
Like we talk on Reddit, I'd like to help with a Dockerfile.

Looking on this PR commits, I first have done using vcpkg and static build. While this is great, the build time and the final image was much bigger.

The other option - that I think it is good enough - needs to change the cmake to remove a CONFIG flag from the CURL and yaml-cpp. Is this fine? I'm honest not sure.

Here is the comparison (built on my machine i5 10500t):

Build static and using vcpkg: 
- Size: 41.6MB
- Time: 2m 54s 15ms

Build shared and using dynamic link:
- Size: 17MB
- Time: 12s 364ms

### Usage example:

1) It is set the `XDG_CONFIG_DIR` to `/config` so users would need to mount a volume pointing to that `/config/presence-for-plex`.

2) It is set `XDG_RUNTIME_DIR` to `/app/run` so users can mount the `discord-ipc-0` to `/app/run/discord-ipc-0`.
  As well, I thought in add a little paragraph about how the app search to it

Ideally the image should would be published to a registry and no need to build it locally

```
docker build . --tag presence-for-plex
docker run --rm \
  -v /run/user/$UID/app/com.discordapp.Discord/discord-ipc-0:/app/run/discord-ipc-0 \
  -v /home/fabricio/.config/presence-for-plex:/config/presence-for-plex \
  presence-for-plex
```

I'm also running it on Docker for Mac (arm64), doing the same thing:

```
docker run --rm \
  -v $TMPDIR/discord-ipc-0:/app/run/discord-ipc-0 \
  -v /home/fabricio/.config/presence-for-plex:/config/presence-for-plex \
  presence-for-plex
```

It would be needed better documentation. But Im honest not great on writing this things down... Hope you - or someone else - can help on this.

Next steps - if this gets in - is to add a workflow to build (multi arch) and push to the registry