### PR TITLE
fix: docker volume should point to /config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apk add --no-cache libstdc++
 COPY --from=build --chmod=755 /src/build/PresenceForPlex /app/
 
 ENV HOME=/app XDG_CONFIG_DIR=/config XDG_RUNTIME_DIR=/app/run
-VOLUME /config/presence-for-plex
+VOLUME /config
 CMD ["/app/PresenceForPlex"]


### PR DESCRIPTION
Files werent persisting due permissions error. 

This way it would create the parent (/config) only and nested should remain fine.

I will later try to write a documentation to how to run the docker.